### PR TITLE
Standardize README: badges, Conda install, License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AcidBase
 
-[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](http://bioconda.github.io/recipes/r-acidbase/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
+[![Install with Bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg)](https://bioconda.github.io/recipes/r-acidbase/README.html) ![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)
 
 Base functions imported by [Acid Genomics][] packages.
 


### PR DESCRIPTION
- Fix bioconda badge link URL from `http://` to `https://`